### PR TITLE
ci: guard release step to only happen on main

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: Set default tag
-       if: ${{ needs.release.status != "success" }}
+       if: ${{ needs.release.status != 'success' }}
        run: echo ::set-output name=imageTag::local
 
      - name: Set version tag
-       if: ${{ needs.release.status == "success" }}
+       if: ${{ needs.release.status == 'success' }}
        run: echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}
     outputs:
       imageTag: ${{ steps.tag.outputs.imageTag }}

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: Set default tag
-       if: ${{ "needs.release.outputs.newVersion" == "" }}
+       if: ${{ needs.release.status != "success" }}
        run: echo ::set-output name=imageTag::local
 
      - name: Set version tag
-       if: ${{ "needs.release.outputs.newVersion" != "" }}
+       if: ${{ needs.release.status == "success" }}
        run: echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}
     outputs:
       imageTag: ${{ steps.tag.outputs.imageTag }}

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -45,13 +45,13 @@ jobs:
     steps:
      - name: Set default tag
        if: ${{ needs.release.status != 'success' }}
-       run: echo ::set-output name=imageTag::local
+       run: echo "IMAGE_TAG=local" >> $GITHUB_ENV
 
      - name: Set version tag
        if: ${{ needs.release.status == 'success' }}
-       run: echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}
+       run: echo "IMAGE_TAG=${{ needs.release.outputs.newVersion }}" >> $GITHUB_ENV
     outputs:
-      imageTag: ${{ steps.tag.outputs.imageTag }}
+      imageTag: ${{ env.IMAGE_TAG }}
 
   build:
     needs: tag

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -43,13 +43,13 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-     - name: Select tag
-       id: tag
-       run: |
-         if [[ "${{ needs.release.outputs.newVersion }}" == "" ]]; then
-           echo ::set-output name=imageTag::local
-         else
-           echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}
+     - name: Set default tag
+       if: ${{ "needs.release.outputs.newVersion" == "" }}
+       run: echo ::set-output name=imageTag::local
+
+     - name: Set version tag
+       if: ${{ "needs.release.outputs.newVersion" != "" }}
+       run: echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}
     outputs:
       imageTag: ${{ steps.tag.outputs.imageTag }}
 

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -37,15 +38,29 @@ jobs:
     outputs:
       newVersion: ${{ steps.tag.outputs.newVersion }}
 
-  build:
+  tag:
     needs: release
-    if: ${{ needs.release.outputs.newVersion }} != ""
-    uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@main
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+     - name: Select tag
+       id: tag
+       run: |
+         if [[ ${{ needs.release.outputs.newVersion }} == "" ]]; then
+           echo ::set-output name=imageTag::local
+         else
+           echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}
+    outputs:
+      imageTag: ${{ steps.tag.outputs.imageTag }}
+
+  build:
+    needs: tag
+    uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@build-push-typo
     with:
       publish: ${{ github.ref == 'refs/heads/main' }}
       repository: ghcr.io/liatrio
       registry-username: ${{ github.repository_owner }}
-      tag: ${{ needs.release.outputs.newVersion }}
+      tag: ${{ needs.tag.outputs.imageTag }}
       image-name: ${{ github.event.repository.name }}
       nofail: true
     secrets:

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -46,7 +46,7 @@ jobs:
      - name: Select tag
        id: tag
        run: |
-         if [[ ${{ needs.release.outputs.newVersion }} == "" ]]; then
+         if [[ "${{ needs.release.outputs.newVersion }}" == "" ]]; then
            echo ::set-output name=imageTag::local
          else
            echo ::set-output name=imageTag::${{ needs.release.outputs.newVersion }}

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -55,6 +55,7 @@ jobs:
 
   build:
     needs: tag
+    if: ${{ always() }}
     uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@build-push-typo
     with:
       publish: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
These changes should cause the workflow to only create releases when on the main branch. However, I'm not entirely sure about the way it's currently written with regards to making sure there is a default tag to pass to the build step.

We could move the if conditional down from the level of the release job to the level of the conventional-release action, and fold the steps from the tag job into the release job, but either way it should function the same.