### PR TITLE
ci: change the registry-username to github.actor

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -40,7 +40,7 @@ jobs:
     with:
       publish: ${{ github.ref == 'refs/heads/main' }}
       repository: ghcr.io/liatrio
-      registry-username: ${{ github.repository_owner }}
+      registry-username: ${{ github.actor }}
       tag: ${{ needs.release.outputs.newVersion }}
       image-name: ${{ github.event.repository.name }}
       nofail: true


### PR DESCRIPTION
I saw some documentation [here](https://github.com/marketplace/actions/docker-login#github-container-registry) and it looks like the registry-username should be the `github.actor` and not `github.repository_owner`. If this isn't the issue, then I think that the issue has something to do with the permissions of the runner not being able to push image to GHCR. This problem is talked about in this documentation page [here](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio).