### PR TITLE
Bengal changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/runatlantis/atlantis:v0.19.7
+FROM ghcr.io/runatlantis/atlantis:v0.19.8
 
 RUN apk update && apk upgrade && \
-  apk add --no-cache aws-cli
+    apk add --no-cache aws-cli
 
 ENV TERRAGRUNT_VERSION 0.38.5
 RUN curl -f -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
-  chmod +x terragrunt && \
-  mv terragrunt /usr/bin && \
-  terragrunt -version
+    chmod +x terragrunt && \
+    mv terragrunt /usr/bin && \
+    terragrunt -version

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Atlantis is a standalone applicaton that can be deployed into one of your enviro
 For an example of Atlantis in action there is [this](https://youtu.be/TmIPWda0IKg) short video.
 
 ## What is installed on this image?
-- Version [0.19.7](https://github.com/runatlantis/atlantis) of the Atlantis application.
+- Version [0.19.8](https://github.com/runatlantis/atlantis) of the Atlantis application.
 - Version [0.38.5](https://terragrunt.gruntwork.io/docs/getting-started/install/) of Terragrunt.
 - Whatever version of Terraform you configure Atlantis to use.
 


### PR DESCRIPTION
Resolved [CVE-2022-30323](https://avd.aquasec.com/nvd/2022/cve-2022-30323/), [CVE-2022-30322](https://avd.aquasec.com/nvd/2022/cve-2022-30322/), [CVE-2022-30321](https://avd.aquasec.com/nvd/2022/cve-2022-30321/) and [CVE-2022-26945](https://avd.aquasec.com/nvd/2022/cve-2022-26945/) with an Atlantis version bump.